### PR TITLE
chore: configuration and connection to rabbitmq

### DIFF
--- a/src/main/java/com/ms/user/configs/RabbitMQConfig.java
+++ b/src/main/java/com/ms/user/configs/RabbitMQConfig.java
@@ -1,0 +1,16 @@
+package com.ms.user.configs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    @Bean
+    public Jackson2JsonMessageConverter messageConverter() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return new Jackson2JsonMessageConverter(objectMapper);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,7 @@ spring.datasource.url= jdbc:postgresql://localhost:5432/ms-user
 spring.datasource.username=root
 spring.datasource.password=root
 spring.jpa.hibernate.ddl-auto=update
+
+spring.rabbitmq.addresses=amqps://kdkjzudw:ZLfDN38aPSsXbwYWu-Md1ljHo2Vy9pA6@whale.rmq.cloudamqp.com/kdkjzudw
+
+broker.queue.email.name=default.email


### PR DESCRIPTION
**Antes de realizar esses passos no microservice user, revise ou faça:
a configuração do rabbitmq para o microservice email
conexão com a instancia + queue
criação da fila
aqui ->  https://github.com/lucas-olvra/MS-Mail/pull/1
**

Neste passo, será feita a conexão com a Queue do RabbitMQ com o microservice de user. Esse microservice será o producer, ou seja, o que enviará algo para a fila criada anteriormente no RabbitMQ: `default.email`

Para isso, é necessário nas propriedades inserir as mesmas informações que foram inseridas no microservice email. Como a URL de conexão com a instancia e o nome dessa fila.

`spring.rabbitmq.addresses=amqps://kdkjzudw:ZLfDN38aPSsXbwYWu-Md1ljHo2Vy9pA6@whale.rmq.cloudamqp.com/kdkjzudw`  
  
`broker.queue.email.name=default.email`

Agora, é necessário fazer a configuração.

Na configuração, diferente do microservice email, a configuração do microservice user não terá a criação da Queue, mas sim terá o MessageConvert para converter o envio em objeto Java,

Com isso, a configuração está realizada.
